### PR TITLE
Increase upper bound on `HUnit`

### DIFF
--- a/DSA.cabal
+++ b/DSA.cabal
@@ -52,7 +52,7 @@ test-suite test-dsa
                   crypto-api                 >= 0.10    && < 0.14,
                   crypto-pubkey-types        >= 0.4     && < 0.6,
                   DRBG                       >= 0.5.2   && < 0.7,
-                  HUnit                      >= 1.3     && < 1.5,
+                  HUnit                      >= 1.3     && < 1.6,
                   QuickCheck                 >= 2.5     && < 3,
                   tagged                     >= 0.2     && < 0.9,
                   test-framework             >= 0.8.0.3 && < 0.10,


### PR DESCRIPTION
`DSA` builds against `HUnit-1.5.0.0` and all tests pass